### PR TITLE
Add automatically updated package statistics

### DIFF
--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -1,0 +1,50 @@
+name: Update package statistics
+
+on:
+  schedule:
+    - cron: "0 6 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-package-statistics
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install cloc
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes cloc
+
+      - name: Refresh statistics
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/update_stats.py
+
+      - name: Commit updated statistics
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "Package statistics are already current."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "Update package statistics"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@ In the following we list a number of open-source packages, that focus on the gen
 
 > Don't hesitate to open an issue to report any package (with a reasonable users base) that is missing from this list
 
+## Package statistics
+
+These statistics are refreshed automatically on the first day of every month.
+Commit metrics use each repository's default branch; lines of code exclude blanks and comments.
+
+<!-- package-stats:start -->
+_Last refreshed: **2026-07-18**_
+
+| Package | Stars | Last commit | Commits | Lines of code |
+| --- | ---: | --- | ---: | ---: |
+| [pyDOE](https://github.com/clicumu/pyDOE2) | 166 | 2021-03-03 | 127 | 14,626 |
+| [DOEPY](https://github.com/tirthajyoti/doepy) | 166 | 2020-09-25 | 56 | 7,943 |
+| [dexpy](https://github.com/statease/dexpy) | 31 | 2018-06-17 | 247 | 6,549 |
+| [diversipy](https://github.com/DavidWalz/diversipy) | 9 | 2020-03-09 | 39 | 1,709 |
+| [Definitive Screening Design](https://github.com/danieleongari/definitive_screening_design) | 14 | 2024-05-28 | 48 | 895 |
+| [pyLHD](https://github.com/toledo60/pyLHD) | 1 | 2024-03-21 | 88 | 72,747 |
+| [BoFire](https://github.com/experimental-design/bofire) | 397 | 2026-07-16 | 687 | 64,231 |
+| [OApackage](https://github.com/eendebakpt/oapackage) | 38 | 2026-02-04 | 959 | 128,482 |
+<!-- package-stats:end -->
+
 ## pyDOE - [GitHub](https://github.com/clicumu/pyDOE2), [Docs](https://pythonhosted.org/pyDOE/)
 
 A collection of "classical" design of experiments.
@@ -144,5 +164,3 @@ The Orthogonal Array package contains functionality to generate and analyse orth
 Analysis of the design:
 
 - D-, Ds-, A-, E- efficiency of the design (`.Defficiency()`, `.DsEfficiency()`, `.Aefficiency()`, `.Eefficiency()`)
-
-

--- a/scripts/update_stats.py
+++ b/scripts/update_stats.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Refresh package repository statistics in README.md."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+
+START_MARKER = "<!-- package-stats:start -->"
+END_MARKER = "<!-- package-stats:end -->"
+PACKAGE_HEADING = re.compile(
+    r"^##\s+(?P<name>.+?)\s+-\s+\[GitHub\]"
+    r"\(https://github\.com/(?P<slug>[^/\s)]+/[^/\s)#?,]+?)(?:\.git)?\)"
+    r"(?:,|$)",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class Package:
+    name: str
+    slug: str
+
+
+@dataclass(frozen=True)
+class GitHubStats:
+    stars: int
+    last_commit: str
+    commits: int
+    default_branch: str
+
+
+@dataclass(frozen=True)
+class PackageStats:
+    package: Package
+    stars: int
+    last_commit: str
+    commits: int
+    lines_of_code: int
+
+
+class GitHubClient:
+    """Minimal GitHub REST API client using only the Python standard library."""
+
+    def __init__(self, token: str | None = None) -> None:
+        self.token = token
+
+    def get(
+        self, path: str, query: Mapping[str, str] | None = None
+    ) -> tuple[object, dict[str, str]]:
+        url = f"https://api.github.com{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query)}"
+
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "awesome-design-of-experiments-stats",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = json.load(response)
+                response_headers = {
+                    key.lower(): value for key, value in response.headers.items()
+                }
+                return payload, response_headers
+        except urllib.error.HTTPError as error:
+            message = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"GitHub API request failed ({error.code}) for {path}: {message}"
+            ) from error
+
+
+def discover_packages(readme: str) -> list[Package]:
+    """Discover package display names and GitHub repositories from README headings."""
+    packages = [
+        Package(match.group("name").strip(), match.group("slug"))
+        for match in PACKAGE_HEADING.finditer(readme)
+    ]
+    if not packages:
+        raise ValueError("No package GitHub links were found in README headings")
+    return packages
+
+
+def total_commits(commits: Sequence[object], link_header: str | None) -> int:
+    """Read a total count from GitHub's pagination Link header."""
+    if not commits:
+        return 0
+    if not link_header:
+        return len(commits)
+
+    for link in link_header.split(","):
+        if 'rel="last"' not in link:
+            continue
+        match = re.search(r"[?&]page=(\d+)", link)
+        if match:
+            return int(match.group(1))
+    return len(commits)
+
+
+def fetch_github_stats(package: Package, client: GitHubClient) -> GitHubStats:
+    """Fetch repository metadata and latest default-branch commit information."""
+    encoded_slug = "/".join(
+        urllib.parse.quote(part, safe="") for part in package.slug.split("/")
+    )
+    repository, _ = client.get(f"/repos/{encoded_slug}")
+    if not isinstance(repository, dict):
+        raise RuntimeError(f"Unexpected repository response for {package.slug}")
+
+    default_branch = str(repository["default_branch"])
+    commits, headers = client.get(
+        f"/repos/{encoded_slug}/commits",
+        {"sha": default_branch, "per_page": "1"},
+    )
+    if not isinstance(commits, list) or not commits:
+        raise RuntimeError(f"No commits found for {package.slug}")
+
+    commit = commits[0]
+    if not isinstance(commit, dict):
+        raise RuntimeError(f"Unexpected commit response for {package.slug}")
+    commit_details = commit.get("commit")
+    if not isinstance(commit_details, dict):
+        raise RuntimeError(f"Missing commit details for {package.slug}")
+    identity = commit_details.get("committer") or commit_details.get("author")
+    if not isinstance(identity, dict) or not identity.get("date"):
+        raise RuntimeError(f"Missing latest commit date for {package.slug}")
+
+    return GitHubStats(
+        stars=int(repository["stargazers_count"]),
+        last_commit=str(identity["date"])[:10],
+        commits=total_commits(commits, headers.get("link")),
+        default_branch=default_branch,
+    )
+
+
+def count_lines_of_code(package: Package, default_branch: str) -> int:
+    """Shallow-clone a repository and count source lines with cloc."""
+    with tempfile.TemporaryDirectory(prefix="doe-package-stats-") as temp_dir:
+        checkout = Path(temp_dir) / "repository"
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--quiet",
+                "--depth",
+                "1",
+                "--single-branch",
+                "--branch",
+                default_branch,
+                f"https://github.com/{package.slug}.git",
+                str(checkout),
+            ],
+            check=True,
+        )
+        result = subprocess.run(
+            ["cloc", "--json", "--quiet", str(checkout)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        report = json.loads(result.stdout)
+        summary = report.get("SUM", {})
+        if "code" not in summary:
+            raise RuntimeError(f"cloc returned no code count for {package.slug}")
+        return int(summary["code"])
+
+
+def collect_stats(
+    packages: Sequence[Package],
+    client: GitHubClient,
+    line_counter: Callable[[Package, str], int] = count_lines_of_code,
+) -> list[PackageStats]:
+    """Collect all metrics while preserving README package order."""
+    rows = []
+    for package in packages:
+        github = fetch_github_stats(package, client)
+        rows.append(
+            PackageStats(
+                package=package,
+                stars=github.stars,
+                last_commit=github.last_commit,
+                commits=github.commits,
+                lines_of_code=line_counter(package, github.default_branch),
+            )
+        )
+    return rows
+
+
+def render_stats(rows: Sequence[PackageStats], refreshed_on: date) -> str:
+    """Render the generated Markdown between the README markers."""
+    lines = [
+        START_MARKER,
+        f"_Last refreshed: **{refreshed_on.isoformat()}**_",
+        "",
+        "| Package | Stars | Last commit | Commits | Lines of code |",
+        "| --- | ---: | --- | ---: | ---: |",
+    ]
+    for row in rows:
+        repository_url = f"https://github.com/{row.package.slug}"
+        lines.append(
+            f"| [{row.package.name}]({repository_url}) "
+            f"| {row.stars:,} | {row.last_commit} | {row.commits:,} "
+            f"| {row.lines_of_code:,} |"
+        )
+    lines.append(END_MARKER)
+    return "\n".join(lines)
+
+
+def replace_stats_block(readme: str, generated_block: str) -> str:
+    """Replace exactly one generated statistics block."""
+    if readme.count(START_MARKER) != 1 or readme.count(END_MARKER) != 1:
+        raise ValueError("README must contain exactly one statistics marker pair")
+    start = readme.index(START_MARKER)
+    end = readme.index(END_MARKER, start) + len(END_MARKER)
+    return f"{readme[:start]}{generated_block}{readme[end:]}"
+
+
+def update_readme(
+    readme_path: Path,
+    client: GitHubClient,
+    refreshed_on: date,
+    line_counter: Callable[[Package, str], int] = count_lines_of_code,
+) -> bool:
+    """Refresh the README and return whether its contents changed."""
+    original = readme_path.read_text(encoding="utf-8")
+    packages = discover_packages(original)
+    rows = collect_stats(packages, client, line_counter)
+    updated = replace_stats_block(original, render_stats(rows, refreshed_on))
+    if updated == original:
+        return False
+    readme_path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--readme",
+        type=Path,
+        default=Path("README.md"),
+        help="README file to update (default: README.md)",
+    )
+    parser.add_argument(
+        "--date",
+        type=date.fromisoformat,
+        default=datetime.now(timezone.utc).date(),
+        help="refresh date in YYYY-MM-DD format (default: current UTC date)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise SystemExit("GITHUB_TOKEN is required")
+    changed = update_readme(args.readme, GitHubClient(token), args.date)
+    print("README statistics updated" if changed else "README statistics unchanged")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_update_stats.py
+++ b/tests/test_update_stats.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from scripts.update_stats import (
+    END_MARKER,
+    START_MARKER,
+    GitHubClient,
+    Package,
+    PackageStats,
+    discover_packages,
+    fetch_github_stats,
+    render_stats,
+    replace_stats_block,
+    total_commits,
+    update_readme,
+)
+
+
+SAMPLE_README = f"""# Packages
+
+## Package statistics
+
+{START_MARKER}
+{END_MARKER}
+
+## Alpha - [GitHub](https://github.com/example/alpha), [Docs](https://example.com)
+
+Description.
+
+## Beta Tool - [GitHub](https://github.com/other/beta)
+
+Description.
+"""
+
+
+class FakeClient(GitHubClient):
+    def __init__(self) -> None:
+        pass
+
+    def get(self, path, query=None):
+        if path.endswith("/commits"):
+            return (
+                [{"commit": {"committer": {"date": "2026-07-17T12:00:00Z"}}}],
+                {
+                    "link": (
+                        '<https://api.github.com/repositories/1/commits?'
+                        'sha=main&per_page=1&page=42>; rel="last"'
+                    )
+                },
+            )
+        return {"default_branch": "main", "stargazers_count": 123}, {}
+
+
+class UpdateStatsTests(unittest.TestCase):
+    def test_discovers_packages_in_readme_order(self):
+        self.assertEqual(
+            discover_packages(SAMPLE_README),
+            [
+                Package("Alpha", "example/alpha"),
+                Package("Beta Tool", "other/beta"),
+            ],
+        )
+
+    def test_rejects_readme_without_packages(self):
+        with self.assertRaisesRegex(ValueError, "No package"):
+            discover_packages("# Empty")
+
+    def test_parses_github_response_and_last_page(self):
+        stats = fetch_github_stats(Package("Alpha", "example/alpha"), FakeClient())
+        self.assertEqual(stats.stars, 123)
+        self.assertEqual(stats.last_commit, "2026-07-17")
+        self.assertEqual(stats.commits, 42)
+        self.assertEqual(stats.default_branch, "main")
+
+    def test_commit_count_handles_unpaginated_and_empty_repositories(self):
+        self.assertEqual(total_commits([{}], None), 1)
+        self.assertEqual(total_commits([], None), 0)
+
+    def test_renders_stable_markdown(self):
+        rendered = render_stats(
+            [
+                PackageStats(
+                    package=Package("Alpha", "example/alpha"),
+                    stars=1234,
+                    last_commit="2026-07-17",
+                    commits=42,
+                    lines_of_code=9876,
+                )
+            ],
+            date(2026, 7, 18),
+        )
+        self.assertIn("_Last refreshed: **2026-07-18**_", rendered)
+        self.assertIn(
+            "| [Alpha](https://github.com/example/alpha) "
+            "| 1,234 | 2026-07-17 | 42 | 9,876 |",
+            rendered,
+        )
+
+    def test_replaces_only_generated_block(self):
+        generated = f"{START_MARKER}\nnew table\n{END_MARKER}"
+        updated = replace_stats_block(SAMPLE_README, generated)
+        self.assertIn(generated, updated)
+        self.assertIn("## Alpha", updated)
+
+    def test_rejects_missing_markers(self):
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            replace_stats_block("# README", "generated")
+
+    def test_update_is_noop_when_generated_content_matches(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "README.md"
+            path.write_text(SAMPLE_README, encoding="utf-8")
+            counter = lambda package, branch: 100
+            client = FakeClient()
+
+            self.assertTrue(
+                update_readme(path, client, date(2026, 7, 18), counter)
+            )
+            first_update = path.read_text(encoding="utf-8")
+            self.assertFalse(
+                update_readme(path, client, date(2026, 7, 18), counter)
+            )
+            self.assertEqual(path.read_text(encoding="utf-8"), first_update)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a generated package statistics table covering all eight listed DOE repositories
- collect stars, latest default-branch commit, total default-branch commits, and source lines of code
- refresh the table on the first day of every month with a write-scoped GitHub Actions workflow
- add deterministic tests for package discovery, API parsing, pagination, Markdown rendering, marker replacement, and no-op updates

## Why

The package list previously offered no at-a-glance activity or size information, and there was no automated way to keep repository metadata current. The updater derives its package list from the existing README headings, so newly listed repositories are included without maintaining a second manifest.

## Impact

Readers can compare package popularity, maintenance recency, commit history, and code size directly in the README. After merge, the scheduled workflow updates only the generated block and skips the commit when a same-day rerun produces no changes.

## Validation

- `python3 -m unittest discover -s tests -v` (8 tests)
- `actionlint -color`
- `git diff --check`
- live refresh against all eight public repositories
- second live refresh returned `README statistics unchanged`

Closes #4