### PR TITLE
Add first-commit and contributor statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,32 +18,34 @@ In the following we list a number of open-source packages that focus on the gene
 ## Package statistics
 
 These statistics are refreshed automatically on the first day of every month.
-Commit metrics use each repository's default branch; lines of code exclude blanks and comments.
+First and last commit dates and commit counts use each repository's default
+branch. Contributor counts include anonymous contributors reported by GitHub.
+Lines of code exclude blanks and comments.
 
 <!-- package-stats:start -->
 _Last refreshed: **2026-07-18**_
 
-| Package | Stars | Last commit | Commits | Lines of code |
-| --- | ---: | --- | ---: | ---: |
-| [PyDOE](https://github.com/pydoe/pydoe) | 326 | 2026-07-17 | 181 | 13,733 |
-| [DOEPY](https://github.com/tirthajyoti/doepy) | 166 | 2020-09-25 | 56 | 7,943 |
-| [dexpy](https://github.com/statease/dexpy) | 31 | 2018-06-17 | 247 | 6,549 |
-| [diversipy](https://github.com/DavidWalz/diversipy) | 9 | 2020-03-09 | 39 | 1,709 |
-| [Definitive Screening Design](https://github.com/danieleongari/definitive_screening_design) | 14 | 2024-05-28 | 48 | 895 |
-| [pyLHD](https://github.com/toledo60/pyLHD) | 1 | 2024-03-21 | 88 | 72,747 |
-| [BoFire](https://github.com/experimental-design/bofire) | 397 | 2026-07-16 | 687 | 64,231 |
-| [OApackage](https://github.com/eendebakpt/oapackage) | 38 | 2026-02-04 | 959 | 128,482 |
-| [PyOptEx](https://github.com/mborn1/pyoptex) | 23 | 2026-06-10 | 341 | 24,512 |
-| [Pyomo.DoE](https://github.com/Pyomo/pyomo) | 2,486 | 2026-07-13 | 31,310 | 441,379 |
-| [OpenTURNS](https://github.com/openturns/openturns) | 340 | 2026-07-16 | 7,757 | 563,774 |
-| [SciPy QMC](https://github.com/scipy/scipy) | 14,827 | 2026-07-18 | 37,890 | 663,500 |
-| [Pyro OED](https://github.com/pyro-ppl/pyro) | 9,022 | 2026-07-10 | 2,516 | 100,342 |
-| [OpenMDAO DOE Driver](https://github.com/OpenMDAO/OpenMDAO) | 754 | 2026-07-17 | 20,871 | 196,186 |
-| [IDAES PySMO Sampling](https://github.com/IDAES/idaes-pse) | 328 | 2026-07-16 | 9,487 | 620,471 |
-| [SALib](https://github.com/SALib/SALib) | 995 | 2026-07-17 | 2,074 | 65,885 |
-| [SMT](https://github.com/SMTorg/smt) | 897 | 2026-06-22 | 1,665 | 136,013 |
-| [UQpy](https://github.com/SURGroup/UQpy) | 361 | 2025-08-19 | 3,058 | 33,244 |
-| [DoEgen](https://github.com/sebhaan/DoEgen) | 102 | 2025-04-24 | 80 | 4,386 |
+| Package | Stars | First Commit | Last Commit | Commits | Lines of code | Contributors |
+| --- | ---: | --- | --- | ---: | ---: | ---: |
+| [PyDOE](https://github.com/pydoe/pydoe) | 326 | 2013-08-27 | 2026-07-17 | 181 | 13,733 | 11 |
+| [DOEPY](https://github.com/tirthajyoti/doepy) | 166 | 2019-07-21 | 2020-09-25 | 56 | 7,943 | 2 |
+| [dexpy](https://github.com/statease/dexpy) | 31 | 2016-09-17 | 2018-06-17 | 247 | 6,549 | 2 |
+| [diversipy](https://github.com/DavidWalz/diversipy) | 9 | 2020-02-19 | 2020-03-09 | 39 | 1,709 | 1 |
+| [Definitive Screening Design](https://github.com/danieleongari/definitive_screening_design) | 14 | 2022-05-10 | 2024-05-28 | 48 | 895 | 3 |
+| [pyLHD](https://github.com/toledo60/pyLHD) | 1 | 2021-08-12 | 2024-03-21 | 88 | 72,747 | 1 |
+| [BoFire](https://github.com/experimental-design/bofire) | 397 | 2022-10-06 | 2026-07-16 | 687 | 64,231 | 40 |
+| [OApackage](https://github.com/eendebakpt/oapackage) | 38 | 2015-01-29 | 2026-02-04 | 959 | 128,482 | 7 |
+| [PyOptEx](https://github.com/mborn1/pyoptex) | 23 | 2023-11-09 | 2026-06-10 | 341 | 24,512 | 6 |
+| [Pyomo.DoE](https://github.com/Pyomo/pyomo) | 2,486 | 2014-10-09 | 2026-07-13 | 31,310 | 441,379 | 201 |
+| [OpenTURNS](https://github.com/openturns/openturns) | 340 | 2015-08-14 | 2026-07-16 | 7,757 | 563,774 | 49 |
+| [SciPy QMC](https://github.com/scipy/scipy) | 14,827 | 2001-02-01 | 2026-07-18 | 37,890 | 663,500 | 1,939 |
+| [Pyro OED](https://github.com/pyro-ppl/pyro) | 9,022 | 2017-06-16 | 2026-07-10 | 2,516 | 100,342 | 163 |
+| [OpenMDAO DOE Driver](https://github.com/OpenMDAO/OpenMDAO) | 754 | 2016-09-20 | 2026-07-17 | 20,871 | 196,186 | 86 |
+| [IDAES PySMO Sampling](https://github.com/IDAES/idaes-pse) | 328 | 2018-12-11 | 2026-07-16 | 9,487 | 620,471 | 106 |
+| [SALib](https://github.com/SALib/SALib) | 995 | 2013-04-02 | 2026-07-17 | 2,074 | 65,885 | 58 |
+| [SMT](https://github.com/SMTorg/smt) | 897 | 2016-11-08 | 2026-06-22 | 1,665 | 136,013 | 43 |
+| [UQpy](https://github.com/SURGroup/UQpy) | 361 | 2017-12-01 | 2025-08-19 | 3,058 | 33,244 | 24 |
+| [DoEgen](https://github.com/sebhaan/DoEgen) | 102 | 2020-11-17 | 2025-04-24 | 80 | 4,386 | 4 |
 <!-- package-stats:end -->
 
 ## General-purpose and dedicated DOE packages

--- a/scripts/update_stats.py
+++ b/scripts/update_stats.py
@@ -37,8 +37,10 @@ class Package:
 @dataclass(frozen=True)
 class GitHubStats:
     stars: int
+    first_commit: str
     last_commit: str
     commits: int
+    contributors: int
     default_branch: str
 
 
@@ -46,9 +48,11 @@ class GitHubStats:
 class PackageStats:
     package: Package
     stars: int
+    first_commit: str
     last_commit: str
     commits: int
     lines_of_code: int
+    contributors: int
 
 
 class GitHubClient:
@@ -98,12 +102,12 @@ def discover_packages(readme: str) -> list[Package]:
     return packages
 
 
-def total_commits(commits: Sequence[object], link_header: str | None) -> int:
+def paginated_total(items: Sequence[object], link_header: str | None) -> int:
     """Read a total count from GitHub's pagination Link header."""
-    if not commits:
+    if not items:
         return 0
     if not link_header:
-        return len(commits)
+        return len(items)
 
     for link in link_header.split(","):
         if 'rel="last"' not in link:
@@ -111,11 +115,24 @@ def total_commits(commits: Sequence[object], link_header: str | None) -> int:
         match = re.search(r"[?&]page=(\d+)", link)
         if match:
             return int(match.group(1))
-    return len(commits)
+    return len(items)
+
+
+def commit_date(commit: object, package: Package) -> str:
+    """Extract a YYYY-MM-DD commit date from a GitHub commit response."""
+    if not isinstance(commit, dict):
+        raise RuntimeError(f"Unexpected commit response for {package.slug}")
+    commit_details = commit.get("commit")
+    if not isinstance(commit_details, dict):
+        raise RuntimeError(f"Missing commit details for {package.slug}")
+    identity = commit_details.get("committer") or commit_details.get("author")
+    if not isinstance(identity, dict) or not identity.get("date"):
+        raise RuntimeError(f"Missing commit date for {package.slug}")
+    return str(identity["date"])[:10]
 
 
 def fetch_github_stats(package: Package, client: GitHubClient) -> GitHubStats:
-    """Fetch repository metadata and latest default-branch commit information."""
+    """Fetch repository, default-branch commit, and contributor information."""
     encoded_slug = "/".join(
         urllib.parse.quote(part, safe="") for part in package.slug.split("/")
     )
@@ -131,20 +148,39 @@ def fetch_github_stats(package: Package, client: GitHubClient) -> GitHubStats:
     if not isinstance(commits, list) or not commits:
         raise RuntimeError(f"No commits found for {package.slug}")
 
-    commit = commits[0]
-    if not isinstance(commit, dict):
-        raise RuntimeError(f"Unexpected commit response for {package.slug}")
-    commit_details = commit.get("commit")
-    if not isinstance(commit_details, dict):
-        raise RuntimeError(f"Missing commit details for {package.slug}")
-    identity = commit_details.get("committer") or commit_details.get("author")
-    if not isinstance(identity, dict) or not identity.get("date"):
-        raise RuntimeError(f"Missing latest commit date for {package.slug}")
+    commit_count = paginated_total(commits, headers.get("link"))
+    if commit_count == 1:
+        oldest_commit = commits[0]
+    else:
+        oldest_commits, _ = client.get(
+            f"/repos/{encoded_slug}/commits",
+            {
+                "sha": default_branch,
+                "per_page": "1",
+                "page": str(commit_count),
+            },
+        )
+        if not isinstance(oldest_commits, list) or not oldest_commits:
+            raise RuntimeError(f"No oldest commit found for {package.slug}")
+        oldest_commit = oldest_commits[0]
+
+    contributors, contributor_headers = client.get(
+        f"/repos/{encoded_slug}/contributors",
+        {"anon": "1", "per_page": "1"},
+    )
+    if not isinstance(contributors, list):
+        raise RuntimeError(
+            f"Unexpected contributors response for {package.slug}"
+        )
 
     return GitHubStats(
         stars=int(repository["stargazers_count"]),
-        last_commit=str(identity["date"])[:10],
-        commits=total_commits(commits, headers.get("link")),
+        first_commit=commit_date(oldest_commit, package),
+        last_commit=commit_date(commits[0], package),
+        commits=commit_count,
+        contributors=paginated_total(
+            contributors, contributor_headers.get("link")
+        ),
         default_branch=default_branch,
     )
 
@@ -194,12 +230,19 @@ def collect_stats(
             PackageStats(
                 package=package,
                 stars=github.stars,
+                first_commit=github.first_commit,
                 last_commit=github.last_commit,
                 commits=github.commits,
                 lines_of_code=line_counter(package, github.default_branch),
+                contributors=github.contributors,
             )
         )
     return rows
+
+
+def render_contributor_count(contributors: int) -> str:
+    """Render a GitHub contributor count."""
+    return f"{contributors:,}"
 
 
 def render_stats(rows: Sequence[PackageStats], refreshed_on: date) -> str:
@@ -208,15 +251,19 @@ def render_stats(rows: Sequence[PackageStats], refreshed_on: date) -> str:
         START_MARKER,
         f"_Last refreshed: **{refreshed_on.isoformat()}**_",
         "",
-        "| Package | Stars | Last commit | Commits | Lines of code |",
-        "| --- | ---: | --- | ---: | ---: |",
+        (
+            "| Package | Stars | First Commit | Last Commit | Commits "
+            "| Lines of code | Contributors |"
+        ),
+        "| --- | ---: | --- | --- | ---: | ---: | ---: |",
     ]
     for row in rows:
         repository_url = f"https://github.com/{row.package.slug}"
         lines.append(
             f"| [{row.package.name}]({repository_url}) "
-            f"| {row.stars:,} | {row.last_commit} | {row.commits:,} "
-            f"| {row.lines_of_code:,} |"
+            f"| {row.stars:,} | {row.first_commit} | {row.last_commit} "
+            f"| {row.commits:,} | {row.lines_of_code:,} "
+            f"| {render_contributor_count(row.contributors)} |"
         )
     lines.append(END_MARKER)
     return "\n".join(lines)

--- a/tests/test_update_stats.py
+++ b/tests/test_update_stats.py
@@ -13,9 +13,10 @@ from scripts.update_stats import (
     PackageStats,
     discover_packages,
     fetch_github_stats,
+    paginated_total,
+    render_contributor_count,
     render_stats,
     replace_stats_block,
-    total_commits,
     update_readme,
 )
 
@@ -47,12 +48,35 @@ class FakeClient(GitHubClient):
 
     def get(self, path, query=None):
         if path.endswith("/commits"):
+            if query and query.get("page") == "42":
+                return (
+                    [
+                        {
+                            "commit": {
+                                "author": {
+                                    "date": "2019-01-02T08:00:00Z"
+                                }
+                            }
+                        }
+                    ],
+                    {},
+                )
             return (
                 [{"commit": {"committer": {"date": "2026-07-17T12:00:00Z"}}}],
                 {
                     "link": (
                         '<https://api.github.com/repositories/1/commits?'
                         'sha=main&per_page=1&page=42>; rel="last"'
+                    )
+                },
+            )
+        if path.endswith("/contributors"):
+            return (
+                [{"login": "example"}],
+                {
+                    "link": (
+                        '<https://api.github.com/repositories/1/contributors?'
+                        'anon=1&per_page=1&page=7>; rel="last"'
                     )
                 },
             )
@@ -76,13 +100,18 @@ class UpdateStatsTests(unittest.TestCase):
     def test_parses_github_response_and_last_page(self):
         stats = fetch_github_stats(Package("Alpha", "example/alpha"), FakeClient())
         self.assertEqual(stats.stars, 123)
+        self.assertEqual(stats.first_commit, "2019-01-02")
         self.assertEqual(stats.last_commit, "2026-07-17")
         self.assertEqual(stats.commits, 42)
+        self.assertEqual(stats.contributors, 7)
         self.assertEqual(stats.default_branch, "main")
 
-    def test_commit_count_handles_unpaginated_and_empty_repositories(self):
-        self.assertEqual(total_commits([{}], None), 1)
-        self.assertEqual(total_commits([], None), 0)
+    def test_pagination_count_handles_unpaginated_and_empty_responses(self):
+        self.assertEqual(paginated_total([{}], None), 1)
+        self.assertEqual(paginated_total([], None), 0)
+
+    def test_contributor_count_uses_thousands_separator(self):
+        self.assertEqual(render_contributor_count(1939), "1,939")
 
     def test_renders_stable_markdown(self):
         rendered = render_stats(
@@ -90,9 +119,11 @@ class UpdateStatsTests(unittest.TestCase):
                 PackageStats(
                     package=Package("Alpha", "example/alpha"),
                     stars=1234,
+                    first_commit="2019-01-02",
                     last_commit="2026-07-17",
                     commits=42,
                     lines_of_code=9876,
+                    contributors=7,
                 )
             ],
             date(2026, 7, 18),
@@ -100,7 +131,7 @@ class UpdateStatsTests(unittest.TestCase):
         self.assertIn("_Last refreshed: **2026-07-18**_", rendered)
         self.assertIn(
             "| [Alpha](https://github.com/example/alpha) "
-            "| 1,234 | 2026-07-17 | 42 | 9,876 |",
+            "| 1,234 | 2019-01-02 | 2026-07-17 | 42 | 9,876 | 7 |",
             rendered,
         )
 


### PR DESCRIPTION
## What changed

- adds **First Commit** and **Contributors** to the generated package statistics table
- keeps the requested column order: Package, Stars, First Commit, Last Commit, Commits, Lines of code, Contributors
- defines first commit as the oldest commit reachable from each repository's default branch
- counts contributors through GitHub's paginated contributors API, including anonymous contributors
- updates the scheduled statistics generator so both fields refresh automatically
- expands the updater tests for oldest-commit lookup, contributor pagination, number formatting, and the new Markdown schema
- refreshes the README with current values for all 19 tracked packages

## Why

The additional fields make it easier to distinguish long-lived projects from newer ones and to compare project breadth beyond stars and commit volume.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -v` — 9 tests passed
- `git diff --check` — clean
- full live statistics refresh completed successfully for all tracked repositories